### PR TITLE
Ensure DZScrollingInspectors unregisters before deallocating.

### DIFF
--- a/TSMiniWebBrowser/TSMiniWebBrowser.m
+++ b/TSMiniWebBrowser/TSMiniWebBrowser.m
@@ -164,9 +164,12 @@ enum actionSheetButtonIndex {
 }
 
 // Remove the webview delegate, because if you use this in a navigation controller, TSMiniWebBrowser can get deallocated while
-// the page is still loading and the web view will call its delegate.
+// the page is still loading and the web view will call its delegate and the same can occur where the DZScrollingInspectors
+// are still observing the scroll view while it's already being deallocated.
 - (void)dealloc
 {
+    self.scrollingInspectorForTopBar = nil;
+    self.scrollingInspectorForBottomBar = nil;
     [self.webView setDelegate:nil];
 }
 


### PR DESCRIPTION
Without this change I’m seeing this on Eigen when using a web browser as a top-level view controller in the tab controller:

```
2015-03-28 00:04:55.781 Artsy[32502:607] An instance 0x797e5300 of class _UIWebViewScrollView was deallocated while key value observers were still registered with it. Observation info was leaked, and may even become mistakenly attached to some other object. Set a breakpoint on NSKVODeallocateBreak to stop here in the debugger. Here's the current observation info:
<NSKeyValueObservationInfo 0x7967e660> (
<NSKeyValueObservance 0x796b9140: Observer: 0x79623510, Key path: contentOffset, Options: <New: YES, Old: YES, Prior: NO> Context: 0x0, Property: 0x7982e9b0>
<NSKeyValueObservance 0x796791e0: Observer: 0x79623510, Key path: contentInset, Options: <New: YES, Old: YES, Prior: NO> Context: 0x0, Property: 0x79827620>
<NSKeyValueObservance 0x796948c0: Observer: 0x79623510, Key path: pan.state, Options: <New: YES, Old: YES, Prior: NO> Context: 0x0, Property: 0x79835e90>
)
(lldb) po 0x79623510
<DZScrollingInspector: 0x79623510>
```
